### PR TITLE
Code quality fix - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.

### DIFF
--- a/src/main/java/org/easetech/easytest/exceptions/ParamAssertionError.java
+++ b/src/main/java/org/easetech/easytest/exceptions/ParamAssertionError.java
@@ -31,7 +31,7 @@ public class ParamAssertionError extends RuntimeException {
 
     public static String join(String delimiter,
             Collection<Object> values) {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         Iterator<Object> iter = values.iterator();
         while (iter.hasNext()) {
             Object next = iter.next();

--- a/src/main/java/org/easetech/easytest/loader/CSVDataLoader.java
+++ b/src/main/java/org/easetech/easytest/loader/CSVDataLoader.java
@@ -123,7 +123,7 @@ public class CSVDataLoader implements Loader {
         data = new HashMap<String, List<Map<String, Object>>>();
         
         while (csvReader.readRecord()) {
-            StringBuffer logBuffer = new StringBuffer("Record being read is :");
+            StringBuilder logBuffer = new StringBuilder("Record being read is :");
             Map<String, Object> actualData = new HashMap<String, Object>();   
             String[] splitValues = csvReader.getValues();
             if (splitValues.length > 0 && "".equals(splitValues[0])) {

--- a/src/main/java/org/easetech/easytest/loader/ExcelDataLoader.java
+++ b/src/main/java/org/easetech/easytest/loader/ExcelDataLoader.java
@@ -142,7 +142,7 @@ public class ExcelDataLoader implements Loader {
             actualData = initializeRowData(row , workbook , actualData);
             
             //Map<String, Object> actualData = new LinkedHashMap<String, Object>();
-            StringBuffer debugInfo = new StringBuffer("Row data being read is ");
+            StringBuilder debugInfo = new StringBuilder("Row data being read is ");
             for (Cell cell : row) {
                 Object cellData = objectFrom(workbook, cell);
                 debugInfo.append(":" + cellData);

--- a/src/main/java/org/easetech/easytest/util/CommonUtils.java
+++ b/src/main/java/org/easetech/easytest/util/CommonUtils.java
@@ -225,7 +225,7 @@ public class CommonUtils {
             return "";
         }
         
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         Iterator it = coll.iterator();
         while (it.hasNext()) {
             sb.append(prefix).append(it.next()).append(suffix);
@@ -317,7 +317,7 @@ public class CommonUtils {
         if (!hasLength(inString) || !hasLength(charsToDelete)) {
             return inString;
         }
-        StringBuffer out = new StringBuffer();
+        StringBuilder out = new StringBuilder();
         for (int i = 0; i < inString.length(); i++) {
             char c = inString.charAt(i);
             if (charsToDelete.indexOf(c) == -1) {
@@ -360,7 +360,7 @@ public class CommonUtils {
             return inString;
         }
 
-        StringBuffer sbuf = new StringBuffer();
+        StringBuilder sbuf = new StringBuilder();
         // output StringBuffer we'll build up
         int pos = 0; // our position in the old string
         int index = inString.indexOf(oldPattern);

--- a/src/main/java/org/easetech/easytest/util/GeneralUtil.java
+++ b/src/main/java/org/easetech/easytest/util/GeneralUtil.java
@@ -467,9 +467,9 @@ public class GeneralUtil {
      * @param Object object
      * @return Character converted value.
      */
-    public static StringBuffer convertToStringBuffer(Object object) {
+    public static StringBuilder convertToStringBuffer(Object object) {
         
-        return (object == null) ? null : new StringBuffer(object.toString());
+        return (object == null) ? null : new StringBuilder(object.toString());
     }
     
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149

Please let me know if you have any questions.

Faisal Hameed