### PR TITLE
Code quality fix - "BigDecimal(double)" should not be used.

### DIFF
--- a/src/main/java/org/easetech/easytest/reports/data/TestMethodDuration.java
+++ b/src/main/java/org/easetech/easytest/reports/data/TestMethodDuration.java
@@ -103,7 +103,7 @@ public class TestMethodDuration implements Serializable {
 	 * @return rounded difference in ms
 	 */
 	public BigDecimal getRoundedMsDifference() {
-		return new BigDecimal((double) getMsDifference());
+		return BigDecimal.valueOf((double) getMsDifference());
 	}
 
 	@Override

--- a/src/main/java/org/easetech/easytest/util/CommonUtils.java
+++ b/src/main/java/org/easetech/easytest/util/CommonUtils.java
@@ -55,7 +55,7 @@ public class CommonUtils {
 	 * @return rounded double
 	 */
 	public static Double getRounded(double valueToRound, int numberOfDecimalPlaces) {
-		BigDecimal bigDecimal = new BigDecimal(valueToRound).setScale(numberOfDecimalPlaces, RoundingMode.HALF_UP);
+		BigDecimal bigDecimal = BigDecimal.valueOf(valueToRound).setScale(numberOfDecimalPlaces, RoundingMode.HALF_UP);
 		return bigDecimal.doubleValue();
 	}
 

--- a/src/main/java/org/easetech/easytest/util/GeneralUtil.java
+++ b/src/main/java/org/easetech/easytest/util/GeneralUtil.java
@@ -65,7 +65,7 @@ public class GeneralUtil {
      * @return rounded double
      */
     public static Double getRounded(double valueToRound, int numberOfDecimalPlaces) {
-        BigDecimal bigDecimal = new BigDecimal(valueToRound).setScale(numberOfDecimalPlaces, RoundingMode.HALF_UP);
+        BigDecimal bigDecimal = BigDecimal.valueOf(valueToRound).setScale(numberOfDecimalPlaces, RoundingMode.HALF_UP);
         return bigDecimal.doubleValue();
     }
     


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2111 -  "BigDecimal(double)" should not be used.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2111

Please let me know if you have any questions.

Faisal Hameed