### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/org/easetech/easytest/converter/ConverterManager.java
+++ b/src/main/java/org/easetech/easytest/converter/ConverterManager.java
@@ -19,6 +19,10 @@ public class ConverterManager {
      * A thread local variable that will hold the set of {@link Converter} for easy consumption by the test cases.
      */
     public static final InheritableThreadLocal<Set<Converter>> converters = new InheritableThreadLocal<Set<Converter>>();
+    
+    private ConverterManager() {
+        
+    }
 
     /**
      * Find the registered Converter for the given class type

--- a/src/main/java/org/easetech/easytest/loader/DataLoaderUtil.java
+++ b/src/main/java/org/easetech/easytest/loader/DataLoaderUtil.java
@@ -38,6 +38,10 @@ public final class DataLoaderUtil {
 
     /** Pattern for runtime expression */
     private static final Pattern RUNTIME_EXPR_PATTERN = Pattern.compile("\\$\\{.*\\}");
+    
+    private DataLoaderUtil() {
+        
+    }
 
 
     /**

--- a/src/main/java/org/easetech/easytest/loader/LoaderFactory.java
+++ b/src/main/java/org/easetech/easytest/loader/LoaderFactory.java
@@ -10,6 +10,10 @@ import junit.framework.Assert;
  */
 public class LoaderFactory {
     
+    private LoaderFactory() {
+        
+    }
+    
     /**
      * Return an instance of {@link Loader} based on the type of file or return null.
      * @param loaderType the type of the loader

--- a/src/main/java/org/easetech/easytest/reports/utils/ChartUtils.java
+++ b/src/main/java/org/easetech/easytest/reports/utils/ChartUtils.java
@@ -29,6 +29,10 @@ import org.jfree.data.general.DefaultPieDataset;
  * 
  */
 public class ChartUtils {
+    
+    private ChartUtils() {
+        
+    }
 
 	/**
 	 * Returns a BufferedImage of JFreeChart object

--- a/src/main/java/org/easetech/easytest/runner/RunnerUtil.java
+++ b/src/main/java/org/easetech/easytest/runner/RunnerUtil.java
@@ -29,6 +29,10 @@ import org.junit.runners.model.TestClass;
  * 
  */
 public class RunnerUtil {
+    
+    private RunnerUtil() {
+        
+    }
 
     public static RunnerScheduler getScheduler(Class<?> testClass) {
         RunnerScheduler scheduler = null;

--- a/src/main/java/org/easetech/easytest/runner/TestConfigUtil.java
+++ b/src/main/java/org/easetech/easytest/runner/TestConfigUtil.java
@@ -32,6 +32,10 @@ public final class TestConfigUtil {
      * An instance of logger associated with the test framework.
      */
     protected static final Logger LOG = LoggerFactory.getLogger(TestConfigUtil.class);
+    
+    private TestConfigUtil() {
+        
+    }
 
     /**
      * Load the test configurations using the provided {@link TestConfigProvider} annotation values

--- a/src/main/java/org/easetech/easytest/strategy/SchedulerStrategy.java
+++ b/src/main/java/org/easetech/easytest/strategy/SchedulerStrategy.java
@@ -18,6 +18,10 @@ import org.junit.runners.model.RunnerScheduler;
  * 
  */
 public class SchedulerStrategy {
+    
+    private SchedulerStrategy() {
+        
+    }
 
     /**
      * Get the correct Scheduler requested by the user based on the {@link Parallel} annotation.

--- a/src/main/java/org/easetech/easytest/util/CommonUtils.java
+++ b/src/main/java/org/easetech/easytest/util/CommonUtils.java
@@ -46,6 +46,10 @@ public class CommonUtils {
     
     /** URL protocol for a file in the file system: "file" */
     public static final String URL_PROTOCOL_FILE = "file";
+    
+    private CommonUtils() {
+        
+    }
 
 	/**
 	 * Rounds a value with number of decimals

--- a/src/main/java/org/easetech/easytest/util/GeneralUtil.java
+++ b/src/main/java/org/easetech/easytest/util/GeneralUtil.java
@@ -56,6 +56,10 @@ public class GeneralUtil {
     private static final Pattern OBJECT_PATTERN = Pattern.compile("\\{.*\\}");
 
     private static final Pattern ARRAY_PATTERN = Pattern.compile("\\[.*\\]");
+    
+    private GeneralUtil() {
+        
+    }
 
     /**
      * Rounds a value with number of decimals


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed